### PR TITLE
Setting up an App Service for Demo API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/terraform/.terraform/
+/terraform/.terraform.lock.hcl
+/terraform/*.tfplan
+/terraform/terraform.tfstate*
+/*.tfvars

--- a/example.tfvars.dist
+++ b/example.tfvars.dist
@@ -1,0 +1,12 @@
+resource_group_name="MyAzureResourceGroup"
+app_tags = {
+  Client  = "Me",
+  Project = "Myself",
+  Owner   = "I"
+}
+app_service_plan_name="ASP-APIM-APIOps"
+app_service_name="AS-APIM-APIOps"
+
+# This configuration allows me to override the default nginx configuration on the App Service
+# See https://www.azurephp.dev/2021/09/php-8-on-azure-app-service/ for more details
+app_command_line="cp config/nginx.default /etc/nginx/sites-available/default && service nginx restart"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,47 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=3.17.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  disable_terraform_partner_id = false
+}
+
+resource "azurerm_resource_group" "resource_group" {
+  name     = var.resource_group_name
+  location = var.app_location
+  tags     = var.app_tags
+}
+
+resource "azurerm_service_plan" "app_service_plan" {
+  name                = var.app_service_plan_name
+  os_type             = var.app_service_plan_os_type
+  sku_name            = var.app_service_plan_sku
+  resource_group_name = azurerm_resource_group.resource_group.name
+  location            = azurerm_resource_group.resource_group.location
+  tags                = azurerm_resource_group.resource_group.tags
+}
+
+resource "azurerm_linux_web_app" "app_service" {
+  name                = var.app_service_name
+  https_only          = var.https_only
+  resource_group_name = azurerm_resource_group.resource_group.name
+  service_plan_id     = azurerm_service_plan.app_service_plan.id
+  location            = azurerm_service_plan.app_service_plan.location
+  tags                = azurerm_service_plan.app_service_plan.tags
+
+  site_config {
+    always_on        = var.always_on
+    app_command_line = var.app_command_line
+    application_stack {
+      php_version   = var.php_version
+    }
+    default_documents = var.default_document_list
+    health_check_path = var.health_check_path
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,79 @@
+variable "resource_group_name" {
+  type        = string
+  description = "The name of the resource group"
+  default     = ""
+}
+variable "app_location" {
+  type        = string
+  description = "The location or region where the application should reside"
+  default     = "West Europe"
+}
+variable "app_tags" {
+  type        = map(string)
+  description = "The tags that should be added to the application"
+  default     = {
+    Client  = "Devoteam",
+    Project = "Demo",
+    Owner   = "Michelangelo van Dam"
+  }
+}
+variable "app_service_plan_name" {
+  type        = string
+  description = "The name for the service plan used by the app service"
+  default     = ""
+}
+variable "app_service_plan_os_type" {
+  type        = string
+  description = "The type of OS for the service plan used by the app service"
+  default     = "Linux"
+}
+variable "app_service_plan_sku" {
+  type        = string
+  description = "The SKU for the service plan used by the app service"
+  default     = "F1"
+}
+variable "app_service_name" {
+  type        = string
+  description = "The name for the app service"
+  default     = ""
+}
+variable "always_on" {
+  type        = bool
+  description = "Should the app service be always on?"
+  default     = false
+}
+variable "https_only" {
+  type        = bool
+  description = "Should the app service be served over HTTPS only?"
+  default     = true
+}
+variable "app_command_line" {
+  type        = string
+  description = "What command should be executed at launch"
+  default     = ""
+}
+variable "current_stack" {
+  type        = string
+  description = "Which technology stack are we using in the application"
+  default     = "php"
+}
+variable "php_version" {
+  type        = string
+  description = "The PHP version for the app service"
+  default     = "8.0"
+}
+variable "default_document_list" {
+  type        = list(string)
+  description = "List of default documents"
+  default     = ["index.php"]
+}
+variable "health_check_path" {
+  type        = string
+  description = "The path to check the health of the application"
+  default     = "/ping"
+}
+variable "http2_enabled" {
+  type        = bool
+  description = "Should HTTP/2 be enabled"
+  default     = true
+}


### PR DESCRIPTION
With this configuration you can set up a resource group, an App Service Plan and an Linux App Service to host a base API service, see https://github.com/vandamm-stib-mivb/apim-demo-api for details of the API.